### PR TITLE
NFC-386 Add new error handling

### DIFF
--- a/Sources/NFCPassportReader/Errors.swift
+++ b/Sources/NFCPassportReader/Errors.swift
@@ -30,6 +30,7 @@ public enum NFCPassportReaderError: Error {
     case NotImplemented
     case TagNotValid
     case ConnectionError
+    case TimeOutError
     case UserCanceled
     case InvalidMRZKey
     case MoreThanOneTagFound
@@ -64,6 +65,7 @@ public enum NFCPassportReaderError: Error {
             case .NotImplemented: return "NotImplemented"
             case .TagNotValid: return "TagNotValid"
             case .ConnectionError: return "ConnectionError"
+            case .TimeOutError: return "TimeOutError"
             case .UserCanceled: return "UserCanceled"
             case .InvalidMRZKey: return "InvalidMRZKey"
             case .MoreThanOneTagFound: return "MoreThanOneTagFound"

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -202,7 +202,9 @@ extension PassportReader : NFCTagReaderSessionDelegate {
                 self.invalidateSession(errorMessage: errorMessage, error: error)
             } catch {
                 if let nfcError = error as? NFCReaderError {
-                    if nfcError.errorCode == NFCReaderError.readerTransceiveErrorTagResponseError.rawValue {
+                    // .readerTransceiveErrorTagResponseError is thrown when a "connection lost" scenario is forced by moving the phone away from the NFC chip
+                    // .readerTransceiveErrorTagConnectionLost is never thrown for this scenario, but added for the sake of completeness
+                    if nfcError.errorCode == NFCReaderError.readerTransceiveErrorTagResponseError.rawValue || nfc.errorCode == NFCReaderError.readerTransceiveErrorTagConnectionLost.rawValue {
                         let errorMessage = NFCViewDisplayMessage.error(NFCPassportReaderError.ConnectionError)
                         self.invalidateSession(errorMessage: errorMessage, error: NFCPassportReaderError.ConnectionError)
                     }

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -13,10 +13,16 @@ import UIKit
 import CoreNFC
 
 @available(iOS 15, *)
+public protocol PassportReaderTrackingDelegate: AnyObject {
+    func nfcTagDetected()
+}
+
+@available(iOS 15, *)
 public class PassportReader : NSObject {
     private typealias NFCCheckedContinuation = CheckedContinuation<NFCPassportModel, Error>
     private var nfcContinuation: NFCCheckedContinuation?
 
+    public weak var trackingDelegate: PassportReaderTrackingDelegate?
     private var passport : NFCPassportModel = NFCPassportModel()
     
     private var readerSession: NFCTagReaderSession?
@@ -285,6 +291,7 @@ extension PassportReader {
     func doBACAuthentication(tagReader : TagReader) async throws {
         self.currentlyReadingDataGroup = nil
         
+        trackingDelegate?.nfcTagDetected()
         Log.info( "Starting Basic Access Control (BAC)" )
         
         self.passport.BACStatus = .failed

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -204,7 +204,7 @@ extension PassportReader : NFCTagReaderSessionDelegate {
                 if let nfcError = error as? NFCReaderError {
                     // .readerTransceiveErrorTagResponseError is thrown when a "connection lost" scenario is forced by moving the phone away from the NFC chip
                     // .readerTransceiveErrorTagConnectionLost is never thrown for this scenario, but added for the sake of completeness
-                    if nfcError.errorCode == NFCReaderError.readerTransceiveErrorTagResponseError.rawValue || nfc.errorCode == NFCReaderError.readerTransceiveErrorTagConnectionLost.rawValue {
+                    if nfcError.errorCode == NFCReaderError.readerTransceiveErrorTagResponseError.rawValue || nfcError.errorCode == NFCReaderError.readerTransceiveErrorTagConnectionLost.rawValue {
                         let errorMessage = NFCViewDisplayMessage.error(NFCPassportReaderError.ConnectionError)
                         self.invalidateSession(errorMessage: errorMessage, error: NFCPassportReaderError.ConnectionError)
                     }


### PR DESCRIPTION
## JIRA
- https://airside.atlassian.net/browse/NFC-386

## Description 
A TimeOutError was added to the NFCPassportReaderError. Moreover, the thrown errors are now handled in the right way for a certain behavior. 

NFC SDK PR: https://github.com/airsidemobile/nfc-sdk-ios/pull/100#issue-2271405965
Habicht PR: https://github.com/airsidemobile/habicht-ios/pull/1931#issue-2271386864
RFC: https://airside.atlassian.net/l/cp/h9EHvXd5