### PR TITLE
Merge upstream rebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Example/Pods
 *.pem
 *.pem_
 .swiftpm
+**masterlist.pem
 
 # Xcode
 #

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,41 @@
+v2.1.1 Implemented a fix for when Active Authentication fails as there are more bytes available - thanks to @petteri-huusko-op 
+
+v2.1.0
+   Bumped minimum version to iOS 14
+   Logging has changed to use OSLog framework.  This removes the different loglevel settings, and the export will only include the last passport read.
+   There is currently an issue reading some passports (I've noticed it with the iPhone 15 Pro) in that the
+       connection with the tag randoly drops.  This also happens with the ReadID app too so suspect its an
+       issue with CoreNFC
+
+   Merged PR 189 - Handle change in MasterList extraction script
+       Changed from CscaMasterListData to pkdMasterListContent - thanks @jakudolejs and @Thormeard
+
+   Merged PR 186 - handle iOS 16 error message when user removed tag during scanning
+       Added additional error check - thanks @TLOn1
+       Added public invalidate method to end tag reader session - thanks @sergeyshalnov
+
+   Merged PR 181 - Expose mapped values for Face Image Information - thanks @TerjeLon
+
+   Merged PR 178 - Improve error reporting of invalid response
+       Updated NFCPassportReaderError.InvalidResponse to provide more information regarding the datagroup and the read tag
+       Added a new error case Unknown(Error) to handle errors not directly handled by the SDK
+       Added tests to cover the improved output
+       dataGroupType is now a computed property. This change makes it readonly and also available when an error needs to be 
+          thrown in parse method
+       Fixed an issue in PassportReader by removing nfcContinuation calls here as this is called in invalidateSession
+       Thanks - @markus-mohemian
+
+   Merged PR 172 - Introduced new display message for activate authentication state
+
+v2.0.3
+   Fix - for issue 170 - DO99 Fatal error provided by @jjynus
+       Guard check for size of rapduBin array
+	
+v2.0.2
+   Fix - change expected response length to -1 in TagReader:selectPassportApplication.
+      Should have been part of @TimoTegtmeier's PR (#153) but missed!
+      Thanks to @Thormeard for spotting this
+
 v2.0.1
    Updated to latest version of OpenSSL - 1.1.1900
    Fixed warnings of publishing updates on background thread when scanning MRZ (example SPM)

--- a/Examples/Example_SPM/NFCPassportReaderApp.xcodeproj/project.pbxproj
+++ b/Examples/Example_SPM/NFCPassportReaderApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/Examples/Example_SPM/NFCPassportReaderApp/Model/SettingsStore.swift
+++ b/Examples/Example_SPM/NFCPassportReaderApp/Model/SettingsStore.swift
@@ -60,15 +60,6 @@ final class SettingsStore: ObservableObject {
         get { defaults.bool(forKey: Keys.captureLog) }
     }
     
-    var logLevel: LogLevel {
-        get {
-            return LogLevel(rawValue:defaults.integer(forKey: Keys.logLevel)) ?? .info
-        }
-        set {
-            defaults.set(newValue.rawValue, forKey: Keys.logLevel)
-        }
-    }
-    
     var useNewVerificationMethod: Bool {
         set { defaults.set(newValue, forKey: Keys.useNewVerification) }
         get { defaults.bool(forKey: Keys.useNewVerification) }

--- a/Examples/Example_SPM/NFCPassportReaderApp/MrzScanner/VisionViewController.swift
+++ b/Examples/Example_SPM/NFCPassportReaderApp/MrzScanner/VisionViewController.swift
@@ -68,6 +68,9 @@ public class VisionViewController: ViewController {
             guard let candidate = visionResult.topCandidates(maximumCandidates).first else { continue }
 			
 			var numberIsSubstring = true
+            
+            // Remove spaces from candidate.string - improves recognition vastly
+            let mrz = candidate.string.replacingOccurrences(of: " ", with: "")
 
 			if let result = candidate.string.checkMrz() {
                 if(result != "nil"){

--- a/Examples/Example_SPM/NFCPassportReaderApp/Views/MainView.swift
+++ b/Examples/Example_SPM/NFCPassportReaderApp/Views/MainView.swift
@@ -7,10 +7,14 @@
 //
 
 import SwiftUI
+import OSLog
 import Combine
 import NFCPassportReader
 import UniformTypeIdentifiers
 import MRZParser
+
+let appLogging = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "app")
+
 
 struct MainView : View {
     @EnvironmentObject var settings: SettingsStore
@@ -24,6 +28,7 @@ struct MainView : View {
     @State private var showSettings : Bool = false
     @State private var showScanMRZ : Bool = false
     @State private var showSavedPassports : Bool = false
+    @State private var gettingLogs : Bool = false
 
     @State var page = 0
     
@@ -80,6 +85,25 @@ struct MainView : View {
                         .disabled( !isValid )
                     }
                 }
+                
+                if gettingLogs {
+                    VStack {
+                        VStack(alignment:.center) {
+                            Text( "Retrieving logs....." )
+                                .font(.title)
+                                .frame(maxWidth:.infinity, maxHeight:150)
+                        }
+                        .shadow(radius: 10)
+                        .background(.white)
+                        .cornerRadius(20) /// make the background rounded
+                        .overlay( /// apply a rounded border
+                            RoundedRectangle(cornerRadius: 20)
+                                .stroke(.gray, lineWidth: 2)
+                        )
+                        .padding()
+                        Spacer()
+                    }
+                }
             }
             .navigationBarTitle("Passport details", displayMode: .automatic)
             .toolbar {
@@ -132,11 +156,17 @@ extension MainView {
 extension MainView {
 
     func shareLogs() {
-        hideKeyboard()
-        PassportUtils.shareLogs()
+        gettingLogs = true
+        Task {
+            hideKeyboard()
+            PassportUtils.shareLogs()
+            gettingLogs = false
+        }
     }
 
     func scanPassport( ) {
+        lastPassportScanTime = Date.now
+
         hideKeyboard()
         self.showDetails = false
         
@@ -162,11 +192,7 @@ extension MainView {
 //        let dataGroups : [DataGroupId] = [.COM, .SOD, .DG1, .DG2, .DG7, .DG11, .DG12, .DG14, .DG15]
 //        passportReader.readPassport(mrzKey: mrzKey, tags:dataGroups, completed: { (passport, error) in
         
-        Log.logLevel = settings.logLevel
-        Log.storeLogs = settings.shouldCaptureLogs
-        Log.clearStoredLogs()
-        
-        Log.error( "Using version \(UIApplication.version)" )
+        appLogging.error( "Using version \(UIApplication.version)" )
         
         Task {
             let customMessageHandler : (NFCViewDisplayMessage)->String? = { (displayMessage) in
@@ -180,7 +206,11 @@ extension MainView {
             }
             
             do {
-                let passport = try await passportReader.readPassport( mrzKey: mrzKey, customDisplayMessage:customMessageHandler)
+                let passport = try await passportReader.readPassport( mrzKey: mrzKey, useExtendedMode: false,  customDisplayMessage:customMessageHandler)
+                
+                if let _ = passport.faceImageInfo {
+                    print( "Got face Image details")
+                }
                 
                 if settings.savePassportOnScan {
                     // Save passport

--- a/Examples/Example_SPM/NFCPassportReaderApp/Views/SettingsView.swift
+++ b/Examples/Example_SPM/NFCPassportReaderApp/Views/SettingsView.swift
@@ -16,22 +16,6 @@ struct SettingsView: View {
 
     var body: some View {
         Form {
-            Section(header: Text("Logging settings")) {
-                Toggle(isOn: $settings.shouldCaptureLogs) {
-                    Text("Should capture logs")
-                }
-                
-                Picker(
-                    selection: $settings.logLevel,
-                    label: Text("Logging level")
-                ) {
-                    ForEach(LogLevel.allCases, id: \.self) {
-                        Text(logLevels[$0.rawValue] ).tag($0)
-                    }
-                }
-
-            }
-            
             Section(header: Text("Passport reading settings")) {
                 Toggle(isOn: $settings.useNewVerificationMethod) {
                     Text("Use new Passive Authentication")

--- a/Examples/Example_SPM/NFCPassportReaderApp/Views/StoredPassportView.swift
+++ b/Examples/Example_SPM/NFCPassportReaderApp/Views/StoredPassportView.swift
@@ -94,9 +94,6 @@ extension StoredPassportView {
     }
     
     func importFile( url : URL ) {
-        Log.logLevel = settings.logLevel
-        Log.storeLogs = settings.shouldCaptureLogs
-        Log.clearStoredLogs()
         
         do {
             let data = try Data(contentsOf: url )

--- a/NFCPassportReader.podspec
+++ b/NFCPassportReader.podspec
@@ -1,14 +1,14 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "NFCPassportReader"
-  spec.version      = "2.0.1"
+  spec.version      = "2.1.1"
   spec.summary      = "This package handles reading an NFC Enabled passport using iOS 13 CoreNFC APIS"
 
   spec.homepage     = "https://github.com/AndyQ/NFCPassportReader"
   spec.license      = "MIT"
   spec.author       = { "Andy Qua" => "andy.qua@gmail.com" }
   spec.platform = :ios
-  spec.ios.deployment_target = "12.0"
+  spec.ios.deployment_target = "14.0"
 
   spec.source       = { :git => "https://github.com/AndyQ/NFCPassportReader.git", :tag => "#{spec.version}" }
 

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/krzyzanowskim/OpenSSL.git", .upToNextMinor(from: "1.1.1900"))
+        .package(url: "https://github.com/krzyzanowskim/OpenSSL.git", .upToNextMinor(from: "1.1.2300"))
 
     ],
     targets: [

--- a/Sources/NFCPassportReader/AES_3DES_DESEncryption.swift
+++ b/Sources/NFCPassportReader/AES_3DES_DESEncryption.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import OSLog
 import CommonCrypto
 
 
@@ -57,7 +58,7 @@ public func AESEncrypt(key:[UInt8], message:[UInt8], iv:[UInt8]) -> [UInt8] {
         
         return [UInt8](cryptData)
     } else {
-        Log.error("AES Encrypt Error: \(cryptStatus)")
+        Logger.passportReader.error("AES Encrypt Error: \(cryptStatus)")
     }
     return []
 }
@@ -110,7 +111,7 @@ public func AESDecrypt(key:[UInt8], message:[UInt8], iv:[UInt8]) -> [UInt8] {
         
         return [UInt8](cryptData)
     } else {
-        Log.error("AES Decrypt Error: \(cryptStatus)")
+        Logger.passportReader.error("AES Decrypt Error: \(cryptStatus)")
     }
     return []
 }
@@ -159,7 +160,7 @@ public func AESECBEncrypt(key:[UInt8], message:[UInt8]) -> [UInt8] {
         
         return [UInt8](cryptData)
     } else {
-        Log.error("AESECBEncrypt Error: \(cryptStatus)")
+        Logger.passportReader.error("AESECBEncrypt Error: \(cryptStatus)")
     }
     return []
 }
@@ -214,7 +215,7 @@ public func tripleDESEncrypt(key:[UInt8], message:[UInt8], iv:[UInt8]) -> [UInt8
         
         return [UInt8](cryptData)
     } else {
-        Log.error("Error: \(cryptStatus)")
+        Logger.passportReader.error("Error: \(cryptStatus)")
     }
     return []
 }
@@ -267,7 +268,7 @@ public func tripleDESDecrypt(key:[UInt8], message:[UInt8], iv:[UInt8]) -> [UInt8
         
         return [UInt8](cryptData)
     } else {
-        Log.error("Error: \(cryptStatus)")
+        Logger.passportReader.error("Error: \(cryptStatus)")
     }
     return []
 }
@@ -319,7 +320,7 @@ public func DESEncrypt(key:[UInt8], message:[UInt8], iv:[UInt8], options:UInt32 
         
         return [UInt8](cryptData)
     } else {
-        Log.error("Error: \(cryptStatus)")
+        Logger.passportReader.error("Error: \(cryptStatus)")
     }
     return []
 }
@@ -370,7 +371,7 @@ public func DESDecrypt(key:[UInt8], message:[UInt8], iv:[UInt8], options:UInt32 
         
         return [UInt8](cryptData)
     } else {
-        Log.error("Error: \(cryptStatus)")
+        Logger.passportReader.error("Error: \(cryptStatus)")
     }
     return []
 }

--- a/Sources/NFCPassportReader/BACHandler.swift
+++ b/Sources/NFCPassportReader/BACHandler.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import OSLog
 
 #if !os(macOS)
 import CoreNFC
@@ -38,36 +39,36 @@ public class BACHandler {
             throw NFCPassportReaderError.NoConnectedTag
         }
         
-        Log.debug( "BACHandler - deriving Document Basic Access Keys" )
+        Logger.bac.debug( "BACHandler - deriving Document Basic Access Keys" )
         _ = try self.deriveDocumentBasicAccessKeys(mrz: mrzKey)
         
         // Make sure we clear secure messaging (could happen if we read an invalid DG or we hit a secure error
         tagReader.secureMessaging = nil
         
         // get Challenge
-        Log.debug( "BACHandler - Getting initial challenge" )
+        Logger.bac.debug( "BACHandler - Getting initial challenge" )
         let response = try await tagReader.getChallenge()
     
-        Log.verbose( "DATA - \(response.data)" )
+        Logger.bac.debug( "DATA - \(response.data)" )
         
-        Log.debug( "BACHandler - Doing mutual authentication" )
+        Logger.bac.debug( "BACHandler - Doing mutual authentication" )
         let cmd_data = self.authentication(rnd_icc: [UInt8](response.data))
         let maResponse = try await tagReader.doMutualAuthentication(cmdData: Data(cmd_data))
-        Log.debug( "DATA - \(maResponse.data)" )
+        Logger.bac.debug( "DATA - \(maResponse.data)" )
         guard maResponse.data.count > 0 else {
             throw NFCPassportReaderError.InvalidMRZKey
         }
         
         let (KSenc, KSmac, ssc) = try self.sessionKeys(data: [UInt8](maResponse.data))
         tagReader.secureMessaging = SecureMessaging(ksenc: KSenc, ksmac: KSmac, ssc: ssc)
-        Log.debug( "BACHandler - complete" )
+        Logger.bac.debug( "BACHandler - complete" )
     }
 
 
     func deriveDocumentBasicAccessKeys(mrz: String) throws -> ([UInt8], [UInt8]) {
         let kseed = generateInitialKseed(kmrz:mrz)
     
-        Log.verbose("Calculate the Basic Access Keys (Kenc and Kmac) using TR-SAC 1.01, 4.2")
+        Logger.bac.debug("Calculate the Basic Access Keys (Kenc and Kmac) using TR-SAC 1.01, 4.2")
         let smskg = SecureMessagingSessionKeyGenerator()
         self.ksenc = try smskg.deriveKey(keySeed: kseed, mode: .ENC_MODE)
         self.ksmac = try smskg.deriveKey(keySeed: kseed, mode: .MAC_MODE)
@@ -88,15 +89,15 @@ public class BACHandler {
     ///
     func generateInitialKseed(kmrz : String ) -> [UInt8] {
         
-        Log.verbose("Calculate the SHA-1 hash of MRZ_information")
-        Log.verbose("\tMRZ KEY - \(kmrz)")
+        Logger.bac.debug("Calculate the SHA-1 hash of MRZ_information")
+        Logger.bac.debug("\tMRZ KEY - \(kmrz)")
         let hash = calcSHA1Hash( [UInt8](kmrz.data(using:.utf8)!) )
         
-        Log.verbose("\tsha1(MRZ_information): \(binToHexRep(hash))")
+        Logger.bac.debug("\tsha1(MRZ_information): \(binToHexRep(hash))")
         
         let subHash = Array(hash[0..<16])
-        Log.verbose("Take the most significant 16 bytes to form the Kseed")
-        Log.verbose("\tKseed: \(binToHexRep(subHash))" )
+        Logger.bac.debug("Take the most significant 16 bytes to form the Kseed")
+        Logger.bac.debug("\tKseed: \(binToHexRep(subHash))" )
         
         return Array(subHash)
     }
@@ -116,38 +117,38 @@ public class BACHandler {
     func authentication( rnd_icc : [UInt8]) -> [UInt8] {
         self.rnd_icc = rnd_icc
         
-        Log.verbose("Request an 8 byte random number from the MRTD's chip")
-        Log.verbose("\tRND.ICC: " + binToHexRep(self.rnd_icc))
+        Logger.bac.debug("Request an 8 byte random number from the MRTD's chip")
+        Logger.bac.debug("\tRND.ICC: '(binToHexRep(self.rnd_icc))")
         
         self.rnd_icc = rnd_icc
 
         let rnd_ifd = generateRandomUInt8Array(8)
         let kifd = generateRandomUInt8Array(16)
         
-        Log.verbose("Generate an 8 byte random and a 16 byte random")
-        Log.verbose("\tRND.IFD: \(binToHexRep(rnd_ifd))" )
-        Log.verbose("\tRND.Kifd: \(binToHexRep(kifd))")
+        Logger.bac.debug("Generate an 8 byte random and a 16 byte random")
+        Logger.bac.debug("\tRND.IFD: \(binToHexRep(rnd_ifd))" )
+        Logger.bac.debug("\tRND.Kifd: \(binToHexRep(kifd))")
         
         let s = rnd_ifd + rnd_icc + kifd
         
-        Log.verbose("Concatenate RND.IFD, RND.ICC and Kifd")
-        Log.verbose("\tS: \(binToHexRep(s))")
+        Logger.bac.debug("Concatenate RND.IFD, RND.ICC and Kifd")
+        Logger.bac.debug("\tS: \(binToHexRep(s))")
         
         let iv : [UInt8] = [0, 0, 0, 0, 0, 0, 0, 0]
         let eifd = tripleDESEncrypt(key: ksenc,message: s, iv: iv)
         
-        Log.verbose("Encrypt S with TDES key Kenc as calculated in Appendix 5.2")
-        Log.verbose("\tEifd: \(binToHexRep(eifd))")
+        Logger.bac.debug("Encrypt S with TDES key Kenc as calculated in Appendix 5.2")
+        Logger.bac.debug("\tEifd: \(binToHexRep(eifd))")
         
         let mifd = mac(algoName: .DES, key: ksmac, msg: pad(eifd, blockSize:8))
 
-        Log.verbose("Compute MAC over eifd with TDES key Kmac as calculated in-Appendix 5.2")
-        Log.verbose("\tMifd: \(binToHexRep(mifd))")
+        Logger.bac.debug("Compute MAC over eifd with TDES key Kmac as calculated in-Appendix 5.2")
+        Logger.bac.debug("\tMifd: \(binToHexRep(mifd))")
         // Construct APDU
         
         let cmd_data = eifd + mifd
-        Log.verbose("Construct command data for MUTUAL AUTHENTICATE")
-        Log.verbose("\tcmd_data: \(binToHexRep(cmd_data))")
+        Logger.bac.debug("Construct command data for MUTUAL AUTHENTICATE")
+        Logger.bac.debug("\tcmd_data: \(binToHexRep(cmd_data))")
         
         self.rnd_ifd = rnd_ifd
         self.kifd = kifd
@@ -162,14 +163,14 @@ public class BACHandler {
     /// @type data: a binary string
     /// @return: A set of two 16 bytes keys (KSenc, KSmac) and the SSC
     public func sessionKeys(data : [UInt8] ) throws -> ([UInt8], [UInt8], [UInt8]) {
-        Log.verbose("Decrypt and verify received data and compare received RND.IFD with generated RND.IFD \(binToHexRep(self.ksmac))" )
+        Logger.bac.debug("Decrypt and verify received data and compare received RND.IFD with generated RND.IFD \(binToHexRep(self.ksmac))" )
         
         let response = tripleDESDecrypt(key: self.ksenc, message: [UInt8](data[0..<32]), iv: [0,0,0,0,0,0,0,0] )
 
         let response_kicc = [UInt8](response[16..<32])
         let Kseed = xor(self.kifd, response_kicc)
-        Log.verbose("Calculate XOR of Kifd and Kicc")
-        Log.verbose("\tKseed: \(binToHexRep(Kseed))" )
+        Logger.bac.debug("Calculate XOR of Kifd and Kicc")
+        Logger.bac.debug("\tKseed: \(binToHexRep(Kseed))" )
         
         let smskg = SecureMessagingSessionKeyGenerator()
         let KSenc = try smskg.deriveKey(keySeed: Kseed, mode: .ENC_MODE)
@@ -178,14 +179,14 @@ public class BACHandler {
 //        let KSenc = self.keyDerivation(kseed: Kseed,c: KENC)
 //        let KSmac = self.keyDerivation(kseed: Kseed,c: KMAC)
         
-        Log.verbose("Calculate Session Keys (KSenc and KSmac) using Appendix 5.1")
-        Log.verbose("\tKSenc: \(binToHexRep(KSenc))" )
-        Log.verbose("\tKSmac: \(binToHexRep(KSmac))" )
+        Logger.bac.debug("Calculate Session Keys (KSenc and KSmac) using Appendix 5.1")
+        Logger.bac.debug("\tKSenc: \(binToHexRep(KSenc))" )
+        Logger.bac.debug("\tKSmac: \(binToHexRep(KSmac))" )
         
         
         let ssc = [UInt8](self.rnd_icc.suffix(4) + self.rnd_ifd.suffix(4))
-        Log.verbose("Calculate Send Sequence Counter")
-        Log.verbose("\tSSC: \(binToHexRep(ssc))" )
+        Logger.bac.debug("Calculate Send Sequence Counter")
+        Logger.bac.debug("\tSSC: \(binToHexRep(ssc))" )
         return (KSenc, KSmac, ssc)
     }
     

--- a/Sources/NFCPassportReader/ChipAuthenticationHandler.swift
+++ b/Sources/NFCPassportReader/ChipAuthenticationHandler.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import OSLog
 import OpenSSL
 
 #if !os(macOS)
@@ -49,7 +50,7 @@ class ChipAuthenticationHandler {
 
     public func doChipAuthentication() async throws  {
                 
-        Log.info( "Performing Chip Authentication - number of public keys found - \(chipAuthPublicKeyInfos.count)" )
+        Logger.chipAuth.info( "Performing Chip Authentication - number of public keys found - \(self.chipAuthPublicKeyInfos.count)" )
         guard isChipAuthenticationSupported else {
             throw NFCPassportReaderError.NotYetSupported( "ChipAuthentication not supported" )
         }
@@ -96,14 +97,14 @@ class ChipAuthenticationHandler {
     /// Apparently works for French passports
     private func inferOID(fromPublicKeyOID: String ) -> String? {
         if fromPublicKeyOID == SecurityInfo.ID_PK_ECDH_OID {
-            Log.warning("No ChipAuthenticationInfo - guessing its id-CA-ECDH-3DES-CBC-CBC");
+            Logger.chipAuth.warning("No ChipAuthenticationInfo - guessing its id-CA-ECDH-3DES-CBC-CBC");
             return SecurityInfo.ID_CA_ECDH_3DES_CBC_CBC_OID
         } else if fromPublicKeyOID == SecurityInfo.ID_PK_DH_OID {
-            Log.warning("No ChipAuthenticationInfo - guessing its id-CA-DH-3DES-CBC-CBC");
+            Logger.chipAuth.warning("No ChipAuthenticationInfo - guessing its id-CA-DH-3DES-CBC-CBC");
             return SecurityInfo.ID_CA_DH_3DES_CBC_CBC_OID
         }
         
-        Log.warning("No ChipAuthenticationInfo and unsupported ChipAuthenticationPublicKeyInfo public key OID \(fromPublicKeyOID)")
+        Logger.chipAuth.warning("No ChipAuthenticationInfo and unsupported ChipAuthenticationPublicKeyInfo public key OID \(fromPublicKeyOID)")
         return nil;
     }
     
@@ -120,7 +121,7 @@ class ChipAuthenticationHandler {
         // Send the public key to the passport
         try await sendPublicKey(oid: oid, keyId: keyId, pcdPublicKey: ephemeralKeyPair!)
             
-        Log.debug( "Public Key successfully sent to passport!" )
+        Logger.chipAuth.debug( "Public Key successfully sent to passport!" )
         
         // Use our ephemeral private key and the passports public key to generate a shared secret
         // (the passport with do the same thing with their private key and our public key)
@@ -177,15 +178,15 @@ class ChipAuthenticationHandler {
         
         let ssc = withUnsafeBytes(of: 0.bigEndian, Array.init)
         if (cipherAlg.hasPrefix("DESede")) {
-            Log.info( "Restarting secure messaging using DESede encryption")
+            Logger.chipAuth.info( "Restarting secure messaging using DESede encryption")
             let sm = SecureMessaging(encryptionAlgorithm: .DES, ksenc: ksEnc, ksmac: ksMac, ssc: ssc)
             tagReader?.secureMessaging = sm
         } else if (cipherAlg.hasPrefix("AES")) {
-            Log.info( "Restarting secure messaging using AES encryption")
+            Logger.chipAuth.info( "Restarting secure messaging using AES encryption")
             let sm = SecureMessaging(encryptionAlgorithm: .AES, ksenc: ksEnc, ksmac: ksMac, ssc: ssc)
             tagReader?.secureMessaging = sm
         } else {
-            Log.error( "Not restarting secure messaging as unsupported cipher algorithm requested - \(cipherAlg)")
+            Logger.chipAuth.error( "Not restarting secure messaging as unsupported cipher algorithm requested - \(cipherAlg)")
             throw NFCPassportReaderError.InvalidDataPassed("Unsupported cipher algorithm \(cipherAlg)" )
         }
     }

--- a/Sources/NFCPassportReader/DataGroups/COM.swift
+++ b/Sources/NFCPassportReader/DataGroups/COM.swift
@@ -5,6 +5,7 @@
 //
 
 import Foundation
+import OSLog
 
 @available(iOS 13, macOS 10.15, *)
 public class COM : DataGroup {
@@ -55,6 +56,6 @@ public class COM : DataGroup {
                 dataGroupsPresent.append( DataGroupParser.dataGroupNames[index] )
             }
         }
-        Log.debug( "DG Found - \(dataGroupsPresent)" )
+        Logger.passportReader.debug( "DG Found - \(self.dataGroupsPresent)" )
     }
 }

--- a/Sources/NFCPassportReader/DataGroups/PACEInfo.swift
+++ b/Sources/NFCPassportReader/DataGroups/PACEInfo.swift
@@ -6,12 +6,24 @@
 //
 
 import Foundation
+import OSLog
 import OpenSSL
 
 public enum PACEMappingType {
     case GM  // Generic Mapping
     case IM  // Integrated Mapping
     case CAM // Chip Authentication Mapping
+    
+    func description () -> String {
+        switch self {
+            case .GM:
+                return "Generic Mapping"
+            case .IM:
+                return "Integrated Mapping"
+            case .CAM:
+                return "Chip Authentication Mapping"
+        }
+    }
 }
 
 @available(iOS 13, macOS 10.15, *)
@@ -115,18 +127,18 @@ public class PACEInfo : SecurityInfo {
         
         switch try getKeyAgreementAlgorithm() {
             case "DH":
-                Log.debug( "Generating DH mapping keys")
+                Logger.pace.debug( "Generating DH mapping keys")
                 //The EVP_PKEY_CTX_set_dh_rfc5114() and EVP_PKEY_CTX_set_dhx_rfc5114() macros are synonymous. They set the DH parameters to the values defined in RFC5114. The rfc5114 parameter must be 1, 2 or 3 corresponding to RFC5114 sections 2.1, 2.2 and 2.3. or 0 to clear the stored value. This macro can be called during parameter generation. The ctx must have a key type of EVP_PKEY_DHX. The rfc5114 parameter and the nid parameter are mutually exclusive.
                 var dhKey : OpaquePointer? = nil
                 switch try getParameterSpec() {
                     case 0:
-                        Log.verbose( "Using DH_get_1024_160" )
+                        Logger.pace.debug( "Using DH_get_1024_160" )
                         dhKey = DH_get_1024_160()
                     case 1:
-                        Log.verbose( "Using DH_get_2048_224" )
+                        Logger.pace.debug( "Using DH_get_2048_224" )
                         dhKey = DH_get_2048_224()
                     case 2:
-                        Log.verbose( "Using DH_get_2048_256" )
+                        Logger.pace.debug( "Using DH_get_2048_256" )
                         dhKey = DH_get_2048_256()
                     default:
                         // Error
@@ -142,7 +154,7 @@ public class PACEInfo : SecurityInfo {
             
             case "ECDH":
                 let parameterSpec = try getParameterSpec()
-                Log.debug( "Generating ECDH mapping keys from parameterSpec - \(parameterSpec)")
+                Logger.pace.debug( "Generating ECDH mapping keys from parameterSpec - \(parameterSpec)")
                 guard let ecKey = EC_KEY_new_by_curve_name(parameterSpec) else {
                     throw NFCPassportReaderError.InvalidDataPassed("Unable to create EC mapping key")
                  }

--- a/Sources/NFCPassportReader/Logging.swift
+++ b/Sources/NFCPassportReader/Logging.swift
@@ -7,62 +7,26 @@
 //
 
 import Foundation
+import OSLog
 
-// TODO: Quick log functions - will move this to something better
-public enum LogLevel : Int, CaseIterable {
-    case verbose = 0
-    case debug = 1
-    case info = 2
-    case warning = 3
-    case error = 4
-    case none = 5
+
+extension Logger {
+    /// Using your bundle identifier is a great way to ensure a unique identifier.
+    private static var subsystem = Bundle.main.bundleIdentifier!
+    
+    /// Tag Reader logs
+    static let passportReader = Logger(subsystem: subsystem, category: "passportReader")
+
+    /// Tag Reader logs
+    static let tagReader = Logger(subsystem: subsystem, category: "tagReader")
+
+    /// SecureMessaging logs
+    static let secureMessaging = Logger(subsystem: subsystem, category: "secureMessaging")
+
+    static let openSSL = Logger(subsystem: subsystem, category: "openSSL")
+
+    static let bac = Logger(subsystem: subsystem, category: "BAC")
+    static let chipAuth = Logger(subsystem: subsystem, category: "chipAuthentication")
+    static let pace = Logger(subsystem: subsystem, category: "PACE")
 }
 
-public class Log {
-    public static var logLevel : LogLevel = .info
-    public static var storeLogs = false
-    public static var logData = [String]()
-    
-    private static let df = DateFormatter()
-    private static var dfInit = false
-
-    public class func verbose( _ msg : @autoclosure () -> String ) {
-        log( .verbose, msg )
-    }
-    public class func debug( _ msg : @autoclosure () -> String ) {
-        log( .debug, msg )
-    }
-    public class func info( _ msg : @autoclosure () -> String ) {
-        log( .info, msg )
-    }
-    public class func warning( _ msg : @autoclosure () -> String ) {
-        log( .warning, msg )
-    }
-    public class func error( _ msg : @autoclosure () -> String ) {
-        log( .error, msg )
-    }
-    
-    public class func clearStoredLogs() {
-        logData.removeAll()
-    }
-    
-    class func log( _ logLevel : LogLevel, _ msg : () -> String ) {
-        guard  logLevel != .none else { return }
-        
-        if !dfInit {
-            df.dateFormat = "y-MM-dd H:m:ss.SSSS"
-            dfInit = true
-        }
-        
-        if self.logLevel.rawValue <= logLevel.rawValue {
-            let message = msg()
-            
-
-            print( "\(df.string(from:Date())) - \(message)" )
-            
-            if storeLogs {
-                logData.append( message )
-            }
-        }
-    }
-}

--- a/Sources/NFCPassportReader/Models/FaceImageInfo.swift
+++ b/Sources/NFCPassportReader/Models/FaceImageInfo.swift
@@ -1,0 +1,161 @@
+//
+//  FaceImageInfo.swift
+//  NFCPassportReader
+//
+//  Created by Terje Lønøy on 22/05/2023.
+//  Copyright © 2023 Andy Qua. All rights reserved.
+//
+
+import Foundation
+
+/**
+ Data structure for storing facial image data. This represents
+ a facial record data block as specified in Section 5.5, 5.6,
+ and 5.7 of ISO/IEC FCD 19794-5 (2004-03-22, AKA Annex D).
+
+ Integration based on [JMRTD](https://sourceforge.net/p/jmrtd/code/HEAD/tree/trunk/jmrtd/src/main/java/org/jmrtd/lds/iso19794/FaceImageInfo.java#l59)
+ */
+public struct FaceImageInfo: Equatable {
+    let expression: Expression?
+    let eyeColor: EyeColor?
+    let faceImageType: FaceImageType?
+    let features: Features?
+    let hairColor: HairColor?
+    let imageColorSpace: ImageColorSpace?
+    let imageDataType: ImageDataType?
+    let sourceType: SourceType?
+    
+    internal static func from(dg2: DataGroup2) -> FaceImageInfo {
+        return FaceImageInfo(
+            expression: Expression.from(dg2.expression),
+            eyeColor: EyeColor.from(dg2.eyeColor),
+            faceImageType: FaceImageType.from(dg2.faceImageType),
+            features: Features.from(dg2.featureMask),
+            hairColor: HairColor.from(dg2.hairColor),
+            imageColorSpace: ImageColorSpace.from(dg2.imageColorSpace),
+            imageDataType: ImageDataType.from(dg2.imageDataType),
+            sourceType: SourceType.from(dg2.sourceType)
+        )
+    }
+    
+    /// Expression code based on Section 5.5.7 of ISO 19794-5.
+    public enum Expression: Int {
+        case unspecified = 0x0000
+        case neutral = 0x0001
+        case smileClosed = 0x0002
+        case smileOpen = 0x0003
+        case raisedEyebrows = 0x0004
+        case eyesLookingAway = 0x0005
+        case squinting = 0x0006
+        case frowning = 0x0007
+        
+        public static func from(_ code: Int) -> Expression? {
+            return Expression(rawValue: code)
+        }
+    }
+
+    /// Eye color code based on Section 5.5.4 of ISO 19794-5.
+    public enum EyeColor: Int {
+        case unspecified = 0x00
+        case black = 0x01
+        case blue = 0x02
+        case brown = 0x03
+        case gray = 0x04
+        case green = 0x05
+        case multiColored = 0x06
+        case pink = 0x07
+        case unknown = 0xFF
+        
+        public static func from(_ code: Int) -> EyeColor? {
+            return EyeColor(rawValue: code)
+        }
+    }
+    
+    /// Face image type code based on Section 5.7.1 of ISO 19794-5.
+    public enum FaceImageType: Int {
+        case basic = 0x00
+        case fullFrontal = 0x01
+        case tokenFrontal = 0x02
+        
+        public static func from(_ code: Int) -> FaceImageType? {
+            return FaceImageType(rawValue: code)
+        }
+    }
+    
+    /// Feature flags meaning based on Section 5.5.6 of ISO 19794-5.
+    public enum Features: Int {
+        case featuresAreSpecified = 0x000001
+        case glasses = 0x000002
+        case moustache = 0x000004
+        case beard = 0x000008
+        case teethVisible = 0x000010
+        case blink = 0x000020
+        case mouthOpen = 0x000040
+        case leftEyePatch = 0x000080
+        case rightEyePath = 0x000100
+        case darkGlasses = 0x000200
+        case distortingMedicalCondition = 0x000400
+        
+        public static func from(_ code: Int) -> Features? {
+            return Features(rawValue: code)
+        }
+    }
+    
+    /// Hair color code based on Section 5.5.5 of ISO 19794-5.
+    public enum HairColor: Int {
+        case unspecified = 0x00
+        case bald = 0x01
+        case black = 0x02
+        case blonde = 0x03
+        case brown = 0x04
+        case gray = 0x05
+        case white = 0x06
+        case red = 0x07
+        case green = 0x08
+        case blue = 0x09
+        case unknown = 0xFF
+        
+        public static func from(_ code: Int) -> HairColor? {
+            return HairColor(rawValue: code)
+        }
+    }
+    
+    /// Color space code based on Section 5.7.4 of ISO 19794-5.
+    public enum ImageColorSpace: Int {
+        case unspecified = 0x00
+        case rgb24 = 0x01
+        case yuv422 = 0x02
+        case gray8 = 0x03
+        case other = 0x04
+        
+        public static func from(_ code: Int) -> ImageColorSpace? {
+            return ImageColorSpace(rawValue: code)
+        }
+    }
+    
+    /// Image data type code based on Section 5.7.2 of ISO 19794-5.
+    public enum ImageDataType: Int {
+        case jpeg = 0x00
+        case jpeg2000 = 0x01
+        
+        public static func from(_ code: Int) -> ImageDataType? {
+            return ImageDataType(rawValue: code)
+        }
+    }
+    
+    /// Source type based on Section 5.7.6 of ISO 19794-5.
+    public enum SourceType: Int {
+        case unspecified = 0x00
+        case staticPhotoUnknownSource = 0x01
+        case staticPhotoDigitalCam = 0x02
+        case staticPhotoScanner = 0x03
+        case videoFrameUnknownSource = 0x04
+        case videoFrameAnalogCam = 0x05
+        case videoFrameDigitalCam = 0x06
+        case unknown = 0x07
+        
+        public static func from(_ code: Int) -> SourceType? {
+            return SourceType(rawValue: code)
+        }
+    }
+}

--- a/Sources/NFCPassportReader/NFCPassportModel.swift
+++ b/Sources/NFCPassportReader/NFCPassportModel.swift
@@ -7,6 +7,7 @@
 
 
 import Foundation
+import OSLog
 
 #if os(iOS)
 import UIKit
@@ -79,6 +80,13 @@ public class NFCPassportModel {
            let personalNumber = dg11.personalNumber { return personalNumber }
         
         return (passportDataElements?["53"] ?? "?").replacingOccurrences(of: "<", with: "" )
+    }()
+    
+    /// face image info
+    public private(set) lazy var faceImageInfo : FaceImageInfo? = {
+        guard let dg2 = dataGroupsRead[.DG2] as? DataGroup2 else { return nil }
+        
+        return FaceImageInfo.from(dg2: dg2)
     }()
 
     public private(set) lazy var documentSigningCertificate : X509Wrapper? = {
@@ -197,7 +205,7 @@ public class NFCPassportModel {
                         let dgId = DataGroupId.getIDFromName(name:key)
                         self.addDataGroup( dgId, dataGroup:dg )
                     } catch {
-                        Log.error("Failed to import Datagroup - \(key) from dump - \(error)" )
+                        Logger.passportReader.error("Failed to import Datagroup - \(key) from dump - \(error)" )
                     }
                 }
             }
@@ -294,9 +302,9 @@ public class NFCPassportModel {
         self.activeAuthenticationChallenge = challenge
         self.activeAuthenticationSignature = signature
         
-        Log.verbose( "Active Authentication")
-        Log.verbose( "   challange - \(binToHexRep(challenge))")
-        Log.verbose( "   signature - \(binToHexRep(signature))")
+        Logger.passportReader.debug( "Active Authentication")
+        Logger.passportReader.debug( "   challange - \(binToHexRep(challenge))")
+        Logger.passportReader.debug( "   signature - \(binToHexRep(signature))")
 
         // Get AA Public key
         self.activeAuthenticationPassed = false
@@ -336,7 +344,7 @@ public class NFCPassportModel {
                         hashType = "SHA224"
                         hashLength = 28  // 224 bits for SHA-224 -> 28 bytes
                     default:
-                        Log.error( "Error identifying Active Authentication RSA message digest hash algorithm" )
+                        Logger.passportReader.error( "Error identifying Active Authentication RSA message digest hash algorithm" )
                         return
                 }
                 
@@ -352,12 +360,12 @@ public class NFCPassportModel {
                 // Check hashes match
                 if msgHash == digest {
                     self.activeAuthenticationPassed = true
-                    Log.debug( "Active Authentication (RSA) successful" )
+                    Logger.passportReader.debug( "Active Authentication (RSA) successful" )
                 } else {
-                    Log.error( "Error verifying Active Authentication RSA signature - Hash doesn't match" )
+                    Logger.passportReader.error( "Error verifying Active Authentication RSA signature - Hash doesn't match" )
                 }
             } catch {
-                Log.error( "Error verifying Active Authentication RSA signature - \(error)" )
+                Logger.passportReader.error( "Error verifying Active Authentication RSA signature - \(error)" )
             }
         } else if let ecdsaPublicKey = dg15.ecdsaPublicKey {
             var digestType = ""
@@ -368,9 +376,9 @@ public class NFCPassportModel {
             
             if OpenSSLUtils.verifyECDSASignature( publicKey:ecdsaPublicKey, signature: signature, data: challenge, digestType: digestType ) {
                 self.activeAuthenticationPassed = true
-                Log.debug( "Active Authentication (ECDSA) successful" )
+                Logger.passportReader.debug( "Active Authentication (ECDSA) successful" )
             } else {
-                Log.error( "Error verifying Active Authentication ECDSA signature" )
+                Logger.passportReader.error( "Error verifying Active Authentication ECDSA signature" )
             }
         }
     }
@@ -412,7 +420,7 @@ public class NFCPassportModel {
             throw error
         }
                 
-        Log.debug( "Passport passed SOD Verification" )
+        Logger.passportReader.debug( "Passport passed SOD Verification" )
         self.passportCorrectlySigned = true
 
     }
@@ -464,11 +472,11 @@ public class NFCPassportModel {
         }
         
         if errors != "" {
-            Log.error( "HASH ERRORS - \(errors)" )
+            Logger.passportReader.error( "HASH ERRORS - \(errors)" )
             throw PassiveAuthenticationError.InvalidDataGroupHash(errors)
         }
         
-        Log.debug( "Passport passed Datagroup Tampering check" )
+        Logger.passportReader.debug( "Passport passed Datagroup Tampering check" )
         passportDataNotTampered = true
     }
     
@@ -524,8 +532,8 @@ public class NFCPassportModel {
             throw PassiveAuthenticationError.UnableToParseSODHashes("Unable to extract hashes" )
         }
 
-        Log.debug( "Parse SOD - Using Algo - \(sodHashAlgo)" )
-        Log.debug( "      - Hashes     - \(sodHashes)" )
+        Logger.passportReader.debug( "Parse SOD - Using Algo - \(sodHashAlgo)" )
+        Logger.passportReader.debug( "      - Hashes     - \(sodHashes)" )
         
         return (sodHashAlgo, sodHashes)
     }

--- a/Sources/NFCPassportReader/NFCViewDisplayMessage.swift
+++ b/Sources/NFCPassportReader/NFCViewDisplayMessage.swift
@@ -13,6 +13,7 @@ public enum NFCViewDisplayMessage {
     case authenticatingWithPassport(Int)
     case readingDataGroupProgress(DataGroupId, Int)
     case error(NFCPassportReaderError)
+    case activeAuthentication
     case successfulRead
 }
 
@@ -43,6 +44,8 @@ extension NFCViewDisplayMessage {
                     default:
                         return "Sorry, there was a problem reading the passport. Please try again"
                 }
+            case .activeAuthentication:
+                return "Authenticating....."
             case .successfulRead:
                 return "Passport read successfully"
         }

--- a/Sources/NFCPassportReader/OpenSSLUtils.swift
+++ b/Sources/NFCPassportReader/OpenSSLUtils.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import OSLog
 import OpenSSL
 import CryptoTokenKit
 
@@ -157,7 +158,7 @@ public class OpenSSLUtils {
                     return String(cString: ptr)
                 }
                 
-                Log.error("error \(cert_error) at \(X509_STORE_CTX_get_error_depth(ctx)) depth lookup:\(val)" )
+                Logger.openSSL.error("error \(cert_error) at \(X509_STORE_CTX_get_error_depth(ctx)) depth lookup:\(val)" )
             }
             
             return ok;
@@ -237,7 +238,7 @@ public class OpenSSLUtils {
             throw OpenSSLError.VerifyAndReturnSODEncapsulatedData("CMS - Verification of P7 failed - unable to verify signature")
         }
         
-        Log.debug("Verification successful\n");
+        Logger.openSSL.debug("Verification successful\n");
         let len = BIO_ctrl(out, BIO_CTRL_PENDING, 0, nil)
         var buffer = [UInt8](repeating: 0, count: len)
         BIO_read(out, &buffer, Int32(len))
@@ -288,7 +289,7 @@ public class OpenSSLUtils {
             let rc = ASN1_parse_dump(out, ptr.baseAddress?.assumingMemoryBound(to: UInt8.self), data.count, 0, 0)
             if rc == 0 {
                 let str = OpenSSLUtils.getOpenSSLError()
-                Log.debug( "Failed to parse ASN1 Data - \(str)" )
+                Logger.openSSL.debug( "Failed to parse ASN1 Data - \(str)" )
                 throw OpenSSLError.UnableToParseASN1("Failed to parse ASN1 Data - \(str)")
             }
             
@@ -546,7 +547,7 @@ public class OpenSSLUtils {
         CMAC_Update(ctx, message, message.count);
         CMAC_Final(ctx, &mac, &maclen);
         
-        Log.verbose( "aesMac - mac - \(binToHexRep(mac))" )
+        Logger.openSSL.debug( "aesMac - mac - \(binToHexRep(mac))" )
         
         return [UInt8](mac[0..<maclen])
     }
@@ -668,34 +669,34 @@ public class OpenSSLUtils {
             secret = [UInt8](repeating: 0, count: Int(DH_size(dh)))
             let len = DH_compute_key(&secret, bn, dh);
             
-            Log.verbose( "OpenSSLUtils.computeSharedSecret - DH secret len - \(len)" )
+            Logger.openSSL.debug( "OpenSSLUtils.computeSharedSecret - DH secret len - \(len)" )
         } else {
             let ctx = EVP_PKEY_CTX_new(privateKeyPair, nil)
             defer{ EVP_PKEY_CTX_free(ctx) }
             
             if EVP_PKEY_derive_init(ctx) != 1 {
                 // error
-                Log.error( "ERROR - \(OpenSSLUtils.getOpenSSLError())" )
+                Logger.openSSL.error( "ERROR - \(OpenSSLUtils.getOpenSSLError())" )
             }
             
             // Set the public key
             if EVP_PKEY_derive_set_peer( ctx, publicKey ) != 1 {
                 // error
-                Log.error( "ERROR - \(OpenSSLUtils.getOpenSSLError())" )
+                Logger.openSSL.error( "ERROR - \(OpenSSLUtils.getOpenSSLError())" )
             }
             
             // get buffer length needed for shared secret
             var keyLen = 0
             if EVP_PKEY_derive(ctx, nil, &keyLen) != 1 {
                 // Error
-                Log.error( "ERROR - \(OpenSSLUtils.getOpenSSLError())" )
+                Logger.openSSL.error( "ERROR - \(OpenSSLUtils.getOpenSSLError())" )
             }
             
             // Derive the shared secret
             secret = [UInt8](repeating: 0, count: keyLen)
             if EVP_PKEY_derive(ctx, &secret, &keyLen) != 1 {
                 // Error
-                Log.error( "ERROR - \(OpenSSLUtils.getOpenSSLError())" )
+                Logger.openSSL.error( "ERROR - \(OpenSSLUtils.getOpenSSLError())" )
             }
         }
         return secret

--- a/Sources/NFCPassportReader/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/NFCPassportReader/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array/>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array/>
+        <key>NSPrivacyTracking</key>
+        <false/>
+    </dict>
+</plist>

--- a/Sources/NFCPassportReader/SecureMessaging.swift
+++ b/Sources/NFCPassportReader/SecureMessaging.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import OSLog
 
 public enum SecureMessagingSupportedAlgorithms {
     case DES
@@ -29,7 +30,7 @@ public class SecureMessaging {
     private var ssc : [UInt8]
     private let algoName : SecureMessagingSupportedAlgorithms
     private let padLength : Int
-    
+        
     public init( encryptionAlgorithm : SecureMessagingSupportedAlgorithms = .DES, ksenc : [UInt8], ksmac : [UInt8], ssc : [UInt8]) {
         self.ksenc = ksenc
         self.ksmac = ksmac
@@ -39,13 +40,13 @@ public class SecureMessaging {
     }
 
     /// Protect the apdu following the doc9303 specification
-    func protect(apdu : NFCISO7816APDU ) throws -> NFCISO7816APDU {
+    func protect(apdu : NFCISO7816APDU, useExtendedMode: Bool = false ) throws -> NFCISO7816APDU {
     
-        Log.verbose("\t\tSSC: " + binToHexRep(self.ssc))
+        Logger.secureMessaging.debug("\t\tSSC: \(binToHexRep(self.ssc))")
         self.ssc = self.incSSC()
         let paddedSSC = algoName == .DES ? self.ssc : [UInt8](repeating: 0, count: 8) + ssc
-        Log.verbose("\tIncrement SSC with 1")
-        Log.verbose("\t\tSSC: " + binToHexRep(self.ssc))
+        Logger.secureMessaging.debug("\tIncrement SSC with 1")
+        Logger.secureMessaging.debug("\t\tSSC: \(binToHexRep(self.ssc))")
 
 
         let cmdHeader = self.maskClassAndPad(apdu: apdu)
@@ -65,21 +66,21 @@ public class SecureMessaging {
         }
         
         let M = cmdHeader + do87 + do97
-        Log.verbose(tmp)
-        Log.verbose("\tM: " + binToHexRep(M))
+        Logger.secureMessaging.debug("\(tmp)")
+        Logger.secureMessaging.debug("\tM: \(binToHexRep(M))")
         
-        Log.verbose("Compute MAC of M")
+        Logger.secureMessaging.debug("Compute MAC of M")
         
         let N = pad(paddedSSC + M, blockSize:padLength)
-        Log.verbose("\tConcatenate SSC and M and add padding")
-        Log.verbose("\t\tN: " + binToHexRep(N))
+        Logger.secureMessaging.debug("\tConcatenate SSC and M and add padding")
+        Logger.secureMessaging.debug("\t\tN: \(binToHexRep(N))")
 
         var CC = mac(algoName: algoName, key: self.ksmac, msg: N)
         if CC.count > 8 {
             CC = [UInt8](CC[0..<8])
         }
-        Log.verbose("\tCompute MAC over N with KSmac")
-        Log.verbose("\t\tCC: " + binToHexRep(CC))
+        Logger.secureMessaging.debug("\tCompute MAC over N with KSmac")
+        Logger.secureMessaging.debug("\t\tCC: \(binToHexRep(CC))")
         
         let do8e = self.buildD08E(mac: CC)
         
@@ -87,7 +88,7 @@ public class SecureMessaging {
         // otherwise its a single byte of size
         let size = do87.count + do97.count + do8e.count
         var dataSize: [UInt8]
-        if size > 255 {
+        if size > 255 || (useExtendedMode && apdu.expectedResponseLength > 231) {
             dataSize = [0x00] + intToBin(size, pad: 4)
         } else {
             dataSize = intToBin(size)
@@ -97,13 +98,13 @@ public class SecureMessaging {
             
         // If the data is more that 255, specify the we are using extended length (0x00, 0x00)
         // Thanks to @filom for the fix!
-        if size > 255 {
+        if size > 255 || (useExtendedMode && apdu.expectedResponseLength > 231) {
             protectedAPDU += [0x00,0x00]
         } else {
             protectedAPDU += [0x00]
         }
-        Log.verbose("Construct and send protected APDU")
-        Log.verbose("\tProtectedAPDU: " + binToHexRep(protectedAPDU))
+        Logger.secureMessaging.debug("Construct and send protected APDU")
+        Logger.secureMessaging.debug("\tProtectedAPDU: \(binToHexRep(protectedAPDU))")
         
         let newAPDU = NFCISO7816APDU(data:Data(protectedAPDU))!
         return newAPDU
@@ -120,8 +121,8 @@ public class SecureMessaging {
         
         self.ssc = self.incSSC()
         let paddedSSC = algoName == .DES ? self.ssc : [UInt8](repeating: 0, count: 8) + ssc
-        Log.verbose("\tIncrement SSC with 1")
-        Log.verbose("\t\tSSC: " + binToHexRep(self.ssc))
+        Logger.secureMessaging.debug("\tIncrement SSC with 1")
+        Logger.secureMessaging.debug("\t\tSSC: \(binToHexRep(self.ssc))")
                 
         // Check for a SM error
         if(rapdu.sw1 != 0x90 || rapdu.sw2 != 0x00) {
@@ -129,8 +130,8 @@ public class SecureMessaging {
         }
 
         let rapduBin = rapdu.data + [rapdu.sw1, rapdu.sw2]
-        Log.verbose("Receive response APDU of MRTD's chip")
-        Log.verbose("\tRAPDU: " + binToHexRep(rapduBin))
+        Logger.secureMessaging.debug("Receive response APDU of MRTD's chip")
+        Logger.secureMessaging.debug("\tRAPDU: \(binToHexRep(rapduBin))")
         
         // DO'87'
         // Mandatory if data is returned, otherwise absent
@@ -150,6 +151,13 @@ public class SecureMessaging {
         
         //DO'99'
         // Mandatory, only absent if SM error occurs
+        guard rapduBin.count >= offset + 5 else {
+            Logger.secureMessaging.error("size error")
+            let returnSw1 = (rapduBin.count >= offset+3) ? rapduBin[offset+2] : 0;
+            let returnSw2 = (rapduBin.count >= offset+4) ? rapduBin[offset+3] : 0;
+            return ResponseAPDU(data: [], sw1: returnSw1, sw2: returnSw2);
+        }
+
         do99 = [UInt8](rapduBin[offset..<offset+4])
         let sw1 = rapduBin[offset+2]
         let sw2 = rapduBin[offset+3]
@@ -176,22 +184,22 @@ public class SecureMessaging {
             if do99.count > 0 {
                 tmp += " DO'99"
             }
-            Log.verbose("Verify RAPDU CC by computing MAC of" + tmp)
+            Logger.secureMessaging.debug("Verify RAPDU CC by computing MAC of \(tmp)")
             
             let K = pad(paddedSSC + do87 + do99, blockSize:padLength)
-            Log.verbose("\tConcatenate SSC and" + tmp + " and add padding")
-            Log.verbose("\t\tK: " + binToHexRep(K))
+            Logger.secureMessaging.debug("\tConcatenate SSC and \(tmp) and add padding")
+            Logger.secureMessaging.debug("\t\tK: \(binToHexRep(K))")
             
-            Log.verbose("\tCompute MAC with KSmac")
+            Logger.secureMessaging.debug("\tCompute MAC with KSmac")
             var CCb = mac(algoName: algoName, key: self.ksmac, msg: K)
             if CCb.count > 8 {
                 CCb = [UInt8](CC[0..<8])
             }
-            Log.verbose("\t\tCC: " + binToHexRep(CCb))
+            Logger.secureMessaging.debug("\t\tCC: \(binToHexRep(CCb))")
             
             let res = (CC == CCb)
-            Log.verbose("\tCompare CC with data of DO'8E of RAPDU")
-            Log.verbose("\t\t\(binToHexRep(CC))  == \(binToHexRep(CCb)) ? \(res)")
+            Logger.secureMessaging.debug("\tCompare CC with data of DO'8E of RAPDU")
+            Logger.secureMessaging.debug("\t\t\(binToHexRep(CC))  == \(binToHexRep(CCb)) ? \(res)")
             
             if !res {
                 throw NFCPassportReaderError.InvalidResponseChecksum
@@ -216,26 +224,26 @@ public class SecureMessaging {
 
             // There is a payload
             data = unpad(dec)
-            Log.verbose("Decrypt data of DO'87 with KSenc")
-            Log.verbose("\tDecryptedData: " + binToHexRep(data))
+            Logger.secureMessaging.debug("Decrypt data of DO'87 with KSenc")
+            Logger.secureMessaging.debug("\tDecryptedData: \(binToHexRep(data))")
         }
         
-        Log.verbose("Unprotected APDU: [\(binToHexRep(data))] \(binToHexRep(sw1)) \(binToHexRep(sw2))" )
+        Logger.secureMessaging.debug("Unprotected APDU: [\(binToHexRep(data))] \(binToHexRep(sw1)) \(binToHexRep(sw2))" )
         return ResponseAPDU(data: data, sw1: sw1, sw2: sw2)
     }
 
     func maskClassAndPad(apdu : NFCISO7816APDU ) -> [UInt8] {
-        Log.verbose("Mask class byte and pad command header")
+        Logger.secureMessaging.debug("Mask class byte and pad command header")
         let res = pad([0x0c, apdu.instructionCode, apdu.p1Parameter, apdu.p2Parameter], blockSize: padLength)
-        Log.verbose("\tCmdHeader: " + binToHexRep(res))
+        Logger.secureMessaging.debug("\tCmdHeader: \(binToHexRep(res))")
         return res
     }
     
     func buildD087(apdu : NFCISO7816APDU) throws -> [UInt8] {
         let cipher = [0x01] + self.padAndEncryptData(apdu)
         let res = try [0x87] + toAsn1Length(cipher.count) + cipher
-        Log.verbose("Build DO'87")
-        Log.verbose("\tDO87: " + binToHexRep(res))
+        Logger.secureMessaging.debug("Build DO'87")
+        Logger.secureMessaging.debug("\tDO87: \(binToHexRep(res))")
         return res
     }
     
@@ -254,10 +262,10 @@ public class SecureMessaging {
             enc = AESEncrypt(key: self.ksenc, message: paddedData, iv: iv)
         }
         
-        Log.verbose("Pad data")
-        Log.verbose("\tData: " + binToHexRep(paddedData))
-        Log.verbose("Encrypt data with KSenc")
-        Log.verbose("\tEncryptedData: " + binToHexRep(enc))
+        Logger.secureMessaging.debug("Pad data")
+        Logger.secureMessaging.debug("\tData: \(binToHexRep(paddedData))")
+        Logger.secureMessaging.debug("Encrypt data with KSenc")
+        Logger.secureMessaging.debug("\tEncryptedData: \(binToHexRep(enc))")
         return enc
     }
     
@@ -271,8 +279,8 @@ public class SecureMessaging {
     
     func buildD08E(mac : [UInt8]) -> [UInt8] {
         let res : [UInt8] = [0x8E, UInt8(mac.count)] + mac
-        Log.verbose("Build DO'8E")
-        Log.verbose("\tDO8E: \(binToHexRep(res))" )
+        Logger.secureMessaging.debug("Build DO'8E")
+        Logger.secureMessaging.debug("\tDO8E: \(binToHexRep(res))" )
         return res
     }
 
@@ -284,8 +292,8 @@ public class SecureMessaging {
         }
         
         let res : [UInt8] = try [0x97] + toAsn1Length(binLe.count) + binLe
-        Log.verbose("Build DO'97")
-        Log.verbose("\tDO97: \(res)")
+        Logger.secureMessaging.debug("Build DO'97")
+        Logger.secureMessaging.debug("\tDO97: \(res)")
         return res
     }
     

--- a/Sources/NFCPassportReader/TagReader.swift
+++ b/Sources/NFCPassportReader/TagReader.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import OSLog
 
 #if !os(macOS)
 import CoreNFC
@@ -48,12 +49,17 @@ public class TagReader {
         return try await send( cmd: cmd )
     }
     
-    func doInternalAuthentication( challenge: [UInt8] ) async throws -> ResponseAPDU {
+    func doInternalAuthentication( challenge: [UInt8], useExtendedMode: Bool ) async throws -> ResponseAPDU {
         let randNonce = Data(challenge)
         
-        let cmd = NFCISO7816APDU(instructionClass: 00, instructionCode: 0x88, p1Parameter: 0, p2Parameter: 0, data: randNonce, expectedResponseLength: 256)
+        var responseLength = 256
+        if useExtendedMode {
+            responseLength = 65535
+        }
+        
+        let cmd = NFCISO7816APDU(instructionClass: 00, instructionCode: 0x88, p1Parameter: 0, p2Parameter: 0, data: randNonce, expectedResponseLength: responseLength)
 
-        return try await send( cmd: cmd )
+        return try await send( cmd: cmd, useExtendedMode: useExtendedMode )
     }
 
     func doMutualAuthentication( cmdData : Data ) async throws -> ResponseAPDU{
@@ -177,7 +183,7 @@ public class TagReader {
         
         var data = [UInt8](resp.data[..<amountRead])
         
-        Log.debug( "TagReader - Number of data bytes to read - \(remaining)" )
+        Logger.tagReader.debug( "TagReader - Number of data bytes to read - \(remaining)" )
         
         var readAmount : Int = maxDataLengthToRead
         while remaining > 0 {
@@ -188,7 +194,7 @@ public class TagReader {
             self.progress?( Int(Float(amountRead) / Float(remaining+amountRead ) * 100))
             let offset = intToBin(amountRead, pad:4)
 
-            Log.verbose( "TagReader - data bytes remaining: \(remaining), will read : \(readAmount)" )
+            Logger.tagReader.debug( "TagReader - data bytes remaining: \(remaining), will read : \(readAmount)" )
             let cmd = NFCISO7816APDU(
                 instructionClass: 00,
                 instructionCode: 0xB0,
@@ -199,12 +205,12 @@ public class TagReader {
             )
             resp = try await self.send( cmd: cmd )
 
-            Log.verbose( "TagReader - got resp - \(binToHexRep(resp.data, asArray: true)), sw1 : \(resp.sw1), sw2 : \(resp.sw2)" )
+            Logger.tagReader.debug( "TagReader - got resp - \(binToHexRep(resp.data, asArray: true)), sw1 : \(resp.sw1), sw2 : \(resp.sw2)" )
             data += resp.data
             
             remaining -= resp.data.count
             amountRead += resp.data.count
-            Log.verbose( "TagReader - Amount of data left to read - \(remaining)" )
+            Logger.tagReader.debug( "TagReader - Amount of data left to read - \(remaining)" )
         }
         
         return data
@@ -233,7 +239,7 @@ public class TagReader {
     
     func selectPassportApplication() async throws -> ResponseAPDU {
         // Finally reselect the eMRTD application so the rest of the reading works as normal
-        Log.debug( "Re-selecting eMRTD Application" )
+        Logger.tagReader.debug( "Re-selecting eMRTD Application" )
         let cmd : NFCISO7816APDU = NFCISO7816APDU(instructionClass: 0x00, instructionCode: 0xA4, p1Parameter: 0x04, p2Parameter: 0x0C, data: Data([0xA0, 0x00, 0x00, 0x02, 0x47, 0x10, 0x01]), expectedResponseLength: -1)
         
         let response = try await self.send( cmd: cmd)
@@ -248,34 +254,45 @@ public class TagReader {
         return try await send( cmd: cmd )
     }
 
-    func send( cmd: NFCISO7816APDU ) async throws -> ResponseAPDU {
-        Log.verbose( "TagReader - sending \(cmd)" )
+    func send( cmd: NFCISO7816APDU, useExtendedMode : Bool = false ) async throws -> ResponseAPDU {
+        Logger.tagReader.debug( "TagReader - sending \(cmd)" )
         var toSend = cmd
         if let sm = secureMessaging {
-            toSend = try sm.protect(apdu:cmd)
-            Log.verbose("TagReader - [SM] \(toSend)" )
+            toSend = try sm.protect(apdu:cmd, useExtendedMode: useExtendedMode)
+            Logger.tagReader.debug("TagReader - [SM] \(toSend)" )
         }
         
-        let (data, sw1, sw2) = try await tag.sendCommand(apdu: toSend)
-        Log.verbose( "TagReader - Received response" )
+        var (data, sw1, sw2) = try await tag.sendCommand(apdu: toSend)
+        Logger.tagReader.debug( "TagReader - Received response, size \(data.count)b" )
+
+        // Some commands may have bigger response than expected. Read the whole response using INS 0xC0 (GET RESPONSE).
+        while (sw1 == 0x61) {
+            let getResponseCmd = NFCISO7816APDU(instructionClass: 0x0, instructionCode: 0xC0, p1Parameter: 0x0, p2Parameter: 0x0, data: Data(), expectedResponseLength: Int(sw2))
+            let nextSegment: Data
+            // Overwrite sw1 and sw2.
+            (nextSegment, sw1, sw2) = try await tag.sendCommand(apdu: getResponseCmd)
+            Logger.tagReader.debug("Read remaining data. Accumulated: \(data.count + nextSegment.count)b. Last batch \(nextSegment.count)b. Still remaining: \(sw2)b")
+            data += nextSegment
+        }
+
         var rep = ResponseAPDU(data: [UInt8](data), sw1: sw1, sw2: sw2)
         
         if let sm = self.secureMessaging {
             rep = try sm.unprotect(rapdu:rep)
-            Log.verbose(String(format:"TagReader [SM - unprotected] \(binToHexRep(rep.data, asArray:true)), sw1:0x%02x sw2:0x%02x", rep.sw1, rep.sw2) )
+            Logger.tagReader.debug("\(String(format:"TagReader [SM - unprotected] \(binToHexRep(rep.data, asArray:true)), sw1:0x%02x sw2:0x%02x", rep.sw1, rep.sw2))" )
         } else {
-            Log.verbose(String(format:"TagReader [unprotected] \(binToHexRep(rep.data, asArray:true)), sw1:0x%02x sw2:0x%02x", rep.sw1, rep.sw2) )
+            Logger.tagReader.debug("\(String(format:"TagReader [unprotected] \(binToHexRep(rep.data, asArray:true)), sw1:0x%02x sw2:0x%02x", rep.sw1, rep.sw2))" )
             
         }
         
         if rep.sw1 != 0x90 && rep.sw2 != 0x00 {
-            Log.error( "Error reading tag: sw1 - 0x\(binToHexRep(sw1)), sw2 - 0x\(binToHexRep(sw2))" )
+            Logger.tagReader.error( "Error reading tag: sw1 - 0x\(binToHexRep(sw1)), sw2 - 0x\(binToHexRep(sw2))" )
             let tagError: NFCPassportReaderError
             if (rep.sw1 == 0x63 && rep.sw2 == 0x00) {
                 tagError = NFCPassportReaderError.InvalidMRZKey
             } else {
                 let errorMsg = self.decodeError(sw1: rep.sw1, sw2: rep.sw2)
-                Log.error( "reason: \(errorMsg)" )
+                Logger.tagReader.error( "reason: \(errorMsg)" )
                 tagError = NFCPassportReaderError.ResponseError( errorMsg, sw1, sw2 )
             }
             throw tagError

--- a/Sources/NFCPassportReader/Utils.swift
+++ b/Sources/NFCPassportReader/Utils.swift
@@ -7,6 +7,8 @@
 //
 
 import Foundation
+import OSLog
+
 import CommonCrypto
 import CryptoTokenKit
 
@@ -184,22 +186,22 @@ public func desMAC(key : [UInt8], msg : [UInt8]) -> [UInt8]{
     let size = msg.count / 8
     var y : [UInt8] = [0,0,0,0,0,0,0,0]
     
-    Log.verbose("Calc mac" )
+    Logger.passportReader.debug("Calc mac" )
     for i in 0 ..< size {
         let tmp = [UInt8](msg[i*8 ..< i*8+8])
-        Log.verbose("x\(i): \(binToHexRep(tmp))" )
+        Logger.passportReader.debug("x\(i): \(binToHexRep(tmp))" )
         y = DESEncrypt(key: [UInt8](key[0..<8]), message: tmp, iv: y)
-        Log.verbose("y\(i): \(binToHexRep(y))" )
+        Logger.passportReader.debug("y\(i): \(binToHexRep(y))" )
     }
     
-    Log.verbose("y: \(binToHexRep(y))" )
-    Log.verbose("bkey: \(binToHexRep([UInt8](key[8..<16])))" )
-    Log.verbose("akey: \(binToHexRep([UInt8](key[0..<8])))" )
+    Logger.passportReader.debug("y: \(binToHexRep(y))" )
+    Logger.passportReader.debug("bkey: \(binToHexRep([UInt8](key[8..<16])))" )
+    Logger.passportReader.debug("akey: \(binToHexRep([UInt8](key[0..<8])))" )
     let iv : [UInt8] = [0,0,0,0,0,0,0,0]
     let b = DESDecrypt(key: [UInt8](key[8..<16]), message: y, iv: iv, options:UInt32(kCCOptionECBMode))
-    Log.verbose( "b: \(binToHexRep(b))" )
+    Logger.passportReader.debug( "b: \(binToHexRep(b))" )
     let a = DESEncrypt(key: [UInt8](key[0..<8]), message: b, iv: iv, options:UInt32(kCCOptionECBMode))
-    Log.verbose( "a: \(binToHexRep(a))" )
+    Logger.passportReader.debug( "a: \(binToHexRep(a))" )
     
     return a
 }

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@ Currently the datagroups supported are: COM, DG1, DG2, DG7, DG11, DG12, DG14 (pa
 This will then handle the reading of the passport, and image and will call the completion block either with an TagError error if there was an error of some kind, or nil if successful.
 
 If successful, the passportReader object will then contain valid data for the passportMRZ and passportImage fields.
+Note - JPEG2000 images are currently unsupported - access to the raw data is available if you need to implement support for those.
 
 In addition, you can customise the messages displayed in the NFC Session Reader by providing a customDisplayMessage callback
 e.g. to override just the initial request to present passport message:

--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -32,6 +32,7 @@ def main( filename ):
         (cns,masterLists) = readAndExtractLDIFFile( filename )
     elif filename.lower().endswith( ".ml" ):
         masterLists = readInMasterListFile( filename )
+        cns = ["MasterList ml file"]
 
     print( f"Read in {len(masterLists)} masterlist files" )
     print( f"Read in {cns} CNS" )
@@ -57,11 +58,12 @@ def readAndExtractLDIFFile( file ):
     cns = []
     cn = ""
     with open(file, "r") as inf:
+        cert = ""
         for line in inf:
             if line.startswith( "cn: "):
                 cn = line[4:]
-            elif line.startswith( "CscaMasterListData:: "):
-                cert = line[21:]
+            elif line.startswith( "pkdMasterListContent:: "):
+                cert = line[23:]
                 adding = True
             elif not line.startswith(" ") and adding == True:
                 adding = False


### PR DESCRIPTION
What did I do?

- `gco integration/airside-customizations`
- `gcb merge-upstream-rebase`
- `git merge integration/airside-customizations-rebase-oct-2024`
- Resolve conflicts  (see diff below)

If we merge this to `integration/airside-customizations` we should have all the changed from upstream plus our own changes. Then we can continue to work off of the same integration branch and don't need to switch around branches every time we make changes.

**Resolved Conflicts**

The conflicts were rather trivial. I resolved them by always taking the change from `origin/integration/airside-customizations-rebase-oct-2024`.

``` diff
diff --cc Sources/NFCPassportReader/PassportReader.swift
index 0d13308,6b2e6d7..0000000
--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@@ -153,16 -155,16 +155,20 @@@ extension PassportReader : NFCTagReader
          } else {
              var userError = NFCPassportReaderError.UnexpectedError
              if let readerError = error as? NFCReaderError {
-                 Log.error( "tagReaderSession:didInvalidateWithError - Got NFCReaderError - \(readerError.localizedDescription)" )
+                 Logger.passportReader.error( "tagReaderSession:didInvalidateWithError - Got NFCReaderError - \(readerError.localizedDescription)" )
                  switch (readerError.code) {
                  case NFCReaderError.readerSessionInvalidationErrorUserCanceled:
-                     Log.error( "     - User cancelled session" )
+                     Logger.passportReader.error( "     - User cancelled session" )
                      userError = NFCPassportReaderError.UserCanceled
                  case NFCReaderError.readerSessionInvalidationErrorSessionTimeout:
++<<<<<<< HEAD
 +                    Log.error("     - Session timeout")
++=======
+                     Logger.passportReader.error("     - Session timeout")
++>>>>>>> origin/integration/airside-customizations-rebase-oct-2024
                      userError = NFCPassportReaderError.TimeOutError
                  default:
-                     Log.error( "     - some other error - \(readerError.localizedDescription)" )
+                     Logger.passportReader.error( "     - some other error - \(readerError.localizedDescription)" )
                      userError = NFCPassportReaderError.UnexpectedError
                  }
              } else {
@@@ -226,6 -228,8 +232,11 @@@
                  let errorMessage = NFCViewDisplayMessage.error(error)
                  self.invalidateSession(errorMessage: errorMessage, error: error)
              } catch {
++<<<<<<< HEAD
++=======
+                 Logger.passportReader.debug( "tagReaderSession:failed to connect to tag - \(error.localizedDescription)" )
+ 
++>>>>>>> origin/integration/airside-customizations-rebase-oct-2024
                  if let nfcError = error as? NFCReaderError {
                      // .readerTransceiveErrorTagResponseError is thrown when a "connection lost" scenario is forced by moving the phone away from the NFC chip
                      // .readerTransceiveErrorTagConnectionLost is never thrown for this scenario, but added for the sake of completeness
@@@ -263,12 -267,12 +274,20 @@@ extension PassportReader 
  
                  trackingDelegate?.readCardAccess(cardAccess: cardAccess)
  
++<<<<<<< HEAD
 +                Log.info( "Starting Password Authenticated Connection Establishment (PACE)" )
++=======
+                 Logger.passportReader.info( "Starting Password Authenticated Connection Establishment (PACE)" )
++>>>>>>> origin/integration/airside-customizations-rebase-oct-2024
                   
                  let paceHandler = try PACEHandler( cardAccess: cardAccess, tagReader: tagReader )
                  try await paceHandler.doPACE(mrzKey: mrzKey )
                  passport.PACEStatus = .success
++<<<<<<< HEAD
 +                Log.debug( "PACE Succeeded" )
++=======
+                 Logger.passportReader.debug( "PACE Succeeded" )
++>>>>>>> origin/integration/airside-customizations-rebase-oct-2024
  
                  trackingDelegate?.paceSucceeded()
              } catch {
@@@ -329,7 -334,7 +349,11 @@@
      func doBACAuthentication(tagReader : TagReader) async throws {
          self.currentlyReadingDataGroup = nil
  
++<<<<<<< HEAD
 +        Log.info( "Starting Basic Access Control (BAC)" )
++=======
+         Logger.passportReader.info( "Starting Basic Access Control (BAC)" )
++>>>>>>> origin/integration/airside-customizations-rebase-oct-2024
          
          self.passport.BACStatus = .failed
  
```