### PR TITLE
[AXC-3403] Improve NFC scanning loading bar

### DIFF
--- a/Sources/NFCPassportReader/DataGroups/DataGroupId.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroupId.swift
@@ -101,5 +101,29 @@ public enum DataGroupId : Int, CaseIterable {
             case .Unknown:  return nil
         }
     }
+    
+    static func getIDFromTag(_ tag: [UInt8]) -> DataGroupId {
+        switch tag {
+            case [0x01, 0x1E]: return .COM
+            case [0x01, 0x01]: return .DG1
+            case [0x01, 0x02]: return .DG2
+            case [0x01, 0x03]: return .DG3
+            case [0x01, 0x04]: return .DG4
+            case [0x01, 0x05]: return .DG5
+            case [0x01, 0x06]: return .DG6
+            case [0x01, 0x07]: return .DG7
+            case [0x01, 0x08]: return .DG8
+            case [0x01, 0x09]: return .DG9
+            case [0x01, 0x0A]: return .DG10
+            case [0x01, 0x0B]: return .DG11
+            case [0x01, 0x0C]: return .DG12
+            case [0x01, 0x0D]: return .DG13
+            case [0x01, 0x0E]: return .DG14
+            case [0x01, 0x0F]: return .DG15
+            case [0x01, 0x10]: return .DG16
+            case [0x01, 0x1D]: return .SOD
+            default: return .Unknown
+        }
+    }
 }
 

--- a/Sources/NFCPassportReader/DataGroups/DataGroupId.swift
+++ b/Sources/NFCPassportReader/DataGroups/DataGroupId.swift
@@ -104,24 +104,24 @@ public enum DataGroupId : Int, CaseIterable {
     
     static func getIDFromTag(_ tag: [UInt8]) -> DataGroupId {
         switch tag {
-            case [0x01, 0x1E]: return .COM
-            case [0x01, 0x01]: return .DG1
-            case [0x01, 0x02]: return .DG2
-            case [0x01, 0x03]: return .DG3
-            case [0x01, 0x04]: return .DG4
-            case [0x01, 0x05]: return .DG5
-            case [0x01, 0x06]: return .DG6
-            case [0x01, 0x07]: return .DG7
-            case [0x01, 0x08]: return .DG8
-            case [0x01, 0x09]: return .DG9
-            case [0x01, 0x0A]: return .DG10
-            case [0x01, 0x0B]: return .DG11
-            case [0x01, 0x0C]: return .DG12
-            case [0x01, 0x0D]: return .DG13
-            case [0x01, 0x0E]: return .DG14
-            case [0x01, 0x0F]: return .DG15
-            case [0x01, 0x10]: return .DG16
-            case [0x01, 0x1D]: return .SOD
+            case DataGroupId.COM.getFileIDTag(): return .COM
+            case DataGroupId.DG1.getFileIDTag(): return .DG1
+            case DataGroupId.DG2.getFileIDTag(): return .DG2
+            case DataGroupId.DG3.getFileIDTag(): return .DG3
+            case DataGroupId.DG4.getFileIDTag(): return .DG4
+            case DataGroupId.DG5.getFileIDTag(): return .DG5
+            case DataGroupId.DG6.getFileIDTag(): return .DG6
+            case DataGroupId.DG7.getFileIDTag(): return .DG7
+            case DataGroupId.DG8.getFileIDTag(): return .DG8
+            case DataGroupId.DG9.getFileIDTag(): return .DG9
+            case DataGroupId.DG10.getFileIDTag(): return .DG10
+            case DataGroupId.DG11.getFileIDTag(): return .DG11
+            case DataGroupId.DG12.getFileIDTag(): return .DG12
+            case DataGroupId.DG13.getFileIDTag(): return .DG13
+            case DataGroupId.DG14.getFileIDTag(): return .DG14
+            case DataGroupId.DG15.getFileIDTag(): return .DG15
+            case DataGroupId.DG16.getFileIDTag(): return .DG16
+            case DataGroupId.SOD.getFileIDTag(): return .SOD
             default: return .Unknown
         }
     }

--- a/Sources/NFCPassportReader/NFCViewDisplayMessage.swift
+++ b/Sources/NFCPassportReader/NFCViewDisplayMessage.swift
@@ -10,7 +10,7 @@ import Foundation
 @available(iOS 13, macOS 10.15, *)
 public enum NFCViewDisplayMessage {
     case requestPresentPassport
-    case authenticatingWithPassport
+    case authenticatingWithPassport(Int)
     case paceAuthenticationPercentage(Int)
     case successfulBACAuthentication
     case successfulComFileRead
@@ -25,7 +25,7 @@ extension NFCViewDisplayMessage {
         switch self {
             case .requestPresentPassport:
                 return "Hold your iPhone near an NFC enabled passport."
-            case .authenticatingWithPassport:
+            case .authenticatingWithPassport(_):
                 return "Authenticating with passport....."
             case .paceAuthenticationPercentage(let percentage):
                 return "PACE authentication progress: \(percentage)%"
@@ -33,7 +33,7 @@ extension NFCViewDisplayMessage {
                 return "Passport authentication successful."
             case .successfulComFileRead:
                 return "COM file read successful."
-            case .readingDataGroupBytes(let dataGroup, let byteSize):
+            case .readingDataGroupBytes(let dataGroup, _):
                 return "Reading \(dataGroup)....."
             case .error(let tagError):
                 switch tagError {

--- a/Sources/NFCPassportReader/NFCViewDisplayMessage.swift
+++ b/Sources/NFCPassportReader/NFCViewDisplayMessage.swift
@@ -10,10 +10,12 @@ import Foundation
 @available(iOS 13, macOS 10.15, *)
 public enum NFCViewDisplayMessage {
     case requestPresentPassport
-    case authenticatingWithPassport(Int)
-    case readingDataGroupProgress(DataGroupId, Int)
+    case authenticatingWithPassport
+    case paceAuthenticationPercentage(Int)
+    case successfulBACAuthentication
+    case successfulComFileRead
+    case readingDataGroupBytes(DataGroupId, Int)
     case error(NFCPassportReaderError)
-    case activeAuthentication
     case successfulRead
 }
 
@@ -23,12 +25,16 @@ extension NFCViewDisplayMessage {
         switch self {
             case .requestPresentPassport:
                 return "Hold your iPhone near an NFC enabled passport."
-            case .authenticatingWithPassport(let progress):
-                let progressString = handleProgress(percentualProgress: progress)
-                return "Authenticating with passport.....\n\n\(progressString)"
-            case .readingDataGroupProgress(let dataGroup, let progress):
-                let progressString = handleProgress(percentualProgress: progress)
-                return "Reading \(dataGroup).....\n\n\(progressString)"
+            case .authenticatingWithPassport:
+                return "Authenticating with passport....."
+            case .paceAuthenticationPercentage(let percentage):
+                return "PACE authentication progress: \(percentage)%"
+            case .successfulBACAuthentication:
+                return "Passport authentication successful."
+            case .successfulComFileRead:
+                return "COM file read successful."
+            case .readingDataGroupBytes(let dataGroup, let byteSize):
+                return "Reading \(dataGroup)....."
             case .error(let tagError):
                 switch tagError {
                     case NFCPassportReaderError.TagNotValid:
@@ -44,17 +50,8 @@ extension NFCViewDisplayMessage {
                     default:
                         return "Sorry, there was a problem reading the passport. Please try again"
                 }
-            case .activeAuthentication:
-                return "Authenticating....."
             case .successfulRead:
                 return "Passport read successfully"
         }
-    }
-    
-    func handleProgress(percentualProgress: Int) -> String {
-        let p = (percentualProgress/20)
-        let full = String(repeating: "🟢 ", count: p)
-        let empty = String(repeating: "⚪️ ", count: 5-p)
-        return "\(full)\(empty)"
     }
 }

--- a/Sources/NFCPassportReader/PACEHandler.swift
+++ b/Sources/NFCPassportReader/PACEHandler.swift
@@ -46,7 +46,7 @@ public class PACEHandler {
 
     var tagReader : TagReader
     var paceInfo : PACEInfo
-    var updateMessageHandler: ((NFCViewDisplayMessage) -> Void?)?
+    var updateMessageHandler: ((NFCViewDisplayMessage) -> Void)?
     
     var isPACESupported : Bool = false
     var paceError : String = ""
@@ -62,7 +62,7 @@ public class PACEHandler {
     private var digestAlg : String = ""
     private var keyLength : Int = -1
     
-    public init(cardAccess : CardAccess, tagReader: TagReader, updateMessageHandler : ((NFCViewDisplayMessage) -> Void?)?) throws {
+    public init(cardAccess : CardAccess, tagReader: TagReader, updateMessageHandler : ((NFCViewDisplayMessage) -> Void)?) throws {
         self.tagReader = tagReader
         
         guard let pi = cardAccess.paceInfo else {

--- a/Sources/NFCPassportReader/PACEHandler.swift
+++ b/Sources/NFCPassportReader/PACEHandler.swift
@@ -62,7 +62,7 @@ public class PACEHandler {
     private var digestAlg : String = ""
     private var keyLength : Int = -1
     
-    public init(cardAccess : CardAccess, tagReader: TagReader, updateMessageHandler : ((NFCViewDisplayMessage) -> Void)?) throws {
+    public init(cardAccess : CardAccess, tagReader: TagReader, updateMessageHandler : ((NFCViewDisplayMessage) -> Void)? = nil) throws {
         self.tagReader = tagReader
         
         guard let pi = cardAccess.paceInfo else {

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -208,7 +208,7 @@ extension PassportReader : NFCTagReaderSessionDelegate {
 
                 Logger.passportReader.debug( "tagReaderSession:connected to tag - starting authentication" )
 
-                self.updateReaderSessionMessage( alertMessage: NFCViewDisplayMessage.authenticatingWithPassport )
+                self.updateReaderSessionMessage( alertMessage: NFCViewDisplayMessage.authenticatingWithPassport(0) )
                 let tagReader = TagReader(tag: passportTag, trackingDelegate: trackingDelegate)
 
                 if let newAmount = self.dataAmountToReadOverride {
@@ -219,7 +219,7 @@ extension PassportReader : NFCTagReaderSessionDelegate {
                     if let dgId = self.currentlyReadingDataGroup {
                         self.updateReaderSessionMessage( alertMessage: NFCViewDisplayMessage.readingDataGroupBytes(dgId, bytesRead) )
                     } else {
-                        self.updateReaderSessionMessage( alertMessage: NFCViewDisplayMessage.authenticatingWithPassport )
+                        self.updateReaderSessionMessage( alertMessage: NFCViewDisplayMessage.authenticatingWithPassport(bytesRead) )
                     }
                 }
 

--- a/Sources/NFCPassportReader/TagReader.swift
+++ b/Sources/NFCPassportReader/TagReader.swift
@@ -18,10 +18,14 @@ public class TagReader {
     var secureMessaging : SecureMessaging?
     var maxDataLengthToRead : Int = 0xA0  // Should be able to use 256 to read arbitrary amounts of data at full speed BUT this isn't supported across all passports so for reliability just use the smaller amount.
 
-    var progress : ((Int)->())?
+    
+    weak var trackingDelegate: PassportReaderTrackingDelegate?
+    
+    var bytesRead : ((Int)->())?
 
-    init( tag: NFCISO7816Tag ) {
+    init( tag: NFCISO7816Tag, trackingDelegate: PassportReaderTrackingDelegate? ) {
         self.tag = tag
+        self.trackingDelegate = trackingDelegate
     }
     
     func overrideDataAmountToRead( newAmount : Int ) {
@@ -180,6 +184,13 @@ public class TagReader {
         let (len, o) = try! asn1Length([UInt8](resp.data[1..<4]))
         var remaining = Int(len)
         var amountRead = o + 1
+        let totalSize = remaining + amountRead
+
+        if case let dataGroupId = DataGroupId.getIDFromTag(tag), dataGroupId != .Unknown {
+            self.trackingDelegate?.trackSize(for: dataGroupId, sizeInBytes: totalSize)
+        }
+
+        self.bytesRead?(amountRead)
         
         var data = [UInt8](resp.data[..<amountRead])
         
@@ -191,7 +202,6 @@ public class TagReader {
                 readAmount = remaining
             }
 
-            self.progress?( Int(Float(amountRead) / Float(remaining+amountRead ) * 100))
             let offset = intToBin(amountRead, pad:4)
 
             Logger.tagReader.debug( "TagReader - data bytes remaining: \(remaining), will read : \(readAmount)" )
@@ -210,7 +220,11 @@ public class TagReader {
             
             remaining -= resp.data.count
             amountRead += resp.data.count
+
+            Logger.tagReader.debug( "TagReader - Read \(resp.data.count) bytes" )
             Logger.tagReader.debug( "TagReader - Amount of data left to read - \(remaining)" )
+
+            self.bytesRead?(resp.data.count)
         }
         
         return data

--- a/Sources/NFCPassportReader/TagReader.swift
+++ b/Sources/NFCPassportReader/TagReader.swift
@@ -23,7 +23,7 @@ public class TagReader {
     
     var bytesRead : ((Int)->())?
 
-    init( tag: NFCISO7816Tag, trackingDelegate: PassportReaderTrackingDelegate? ) {
+    init( tag: NFCISO7816Tag, trackingDelegate: PassportReaderTrackingDelegate? = nil ) {
         self.tag = tag
         self.trackingDelegate = trackingDelegate
     }


### PR DESCRIPTION
[AXC-3403](https://airside.atlassian.net/browse/AXC-3403)

This PR makes changes in what is tracked, and how it is tracked. Before, it was just tracked whenever a data group was fully read. However, since the data groups had drastically different sizes (~90 bytes to ~18kb), the loading bar was very chunky and not continuous at all.

Therefore, the following changes are made:
- Track the read byte size instead of data groups
- Track the total size of each individual data group
- Add tracking for:
      - .COM file read
      - BAC authentication
      - PACE authentication
 
Related to https://github.com/airsidemobile/nfc-sdk-ios/pull/142 and https://github.com/airsidemobile/habicht-ios/pull/2281.

[AXC-3403]: https://airside.atlassian.net/browse/AXC-3403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ