### PR TITLE
[AXC-3476] Re-enable excluded arm64 architecture

### DIFF
--- a/NFCPassportReader.podspec
+++ b/NFCPassportReader.podspec
@@ -19,9 +19,4 @@ Pod::Spec.new do |spec|
   spec.dependency "OpenSSL-Universal", '1.1.1900'
   spec.xcconfig          = { 'OTHER_LDFLAGS' => '-weak_framework CryptoKit -weak_framework CoreNFC -weak_framework CryptoTokenKit' }
 
-  spec.pod_target_xcconfig = {
-    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
-  }
-  spec.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-
 end


### PR DESCRIPTION
## 🎫 Ticket

- https://airside.atlassian.net/browse/AXC-3476

## 👀 Related pull requests

- https://github.com/airsidemobile/nfc-sdk-ios/pull/155
- https://github.com/airsidemobile/habicht-ios/pull/2336

## 📖 Description

The exclusion of `arm64` for the iPhone simulator was likely introduced to address compatibility issues with certain dependencies in the past. However, as all dependencies now fully support the `arm64` architecture ([as mentioned here](https://github.com/AndyQ/NFCPassportReader/pull/230)), this exclusion is no longer required.

Given recent issues and complications arising from this configuration in the [nfc-sdk-ios](https://github.com/airsidemobile/nfc-sdk-ios), along with the need to update the CI pipeline to use Xcode 16 instead of Xcode 15, I have removed this exclusion.